### PR TITLE
Use _Bool in API header, as per C99 standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - '!main'
 
 env:
-  BUILDER_VERSION: v0.7.6
+  BUILDER_VERSION: v0.8.9
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-ffi

--- a/src/api.h
+++ b/src/api.h
@@ -290,13 +290,13 @@ AWS_CRT_API void aws_crt_signing_config_aws_set_service(
     size_t service_length);
 AWS_CRT_API void aws_crt_signing_config_aws_set_use_double_uri_encode(
     aws_crt_signing_config_aws *signing_config,
-    bool use_double_uri_encode);
+    _Bool use_double_uri_encode);
 AWS_CRT_API void aws_crt_signing_config_aws_set_should_normalize_uri_path(
     aws_crt_signing_config_aws *signing_config,
-    bool should_normalize_uri_path);
+    _Bool should_normalize_uri_path);
 AWS_CRT_API void aws_crt_signing_config_aws_set_omit_session_token(
     aws_crt_signing_config_aws *signing_config,
-    bool omit_session_token);
+    _Bool omit_session_token);
 AWS_CRT_API void aws_crt_signing_config_aws_set_signed_body_value(
     aws_crt_signing_config_aws *signing_config,
     const uint8_t *signed_body,


### PR DESCRIPTION
Solves the problem of allowing api.h to be parsed independently.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
