### PR TITLE
Add bindings for should_sign_header_fn

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -296,6 +296,7 @@ typedef enum aws_crt_signed_body_header_type {
     AWS_CRT_SIGNED_BODY_HEADER_TYPE_NONE,
     AWS_CRT_SIGNED_BODY_HEADER_TYPE_X_AMZ_CONTENT_SHA256,
 } aws_crt_signed_body_header_type;
+typedef bool(aws_crt_should_sign_header_fn)(const struct aws_byte_cursor *name, void *userdata);
 AWS_CRT_API aws_crt_signing_config_aws *aws_crt_signing_config_aws_new(void);
 AWS_CRT_API void aws_crt_signing_config_aws_release(aws_crt_signing_config_aws *signing_config);
 
@@ -338,6 +339,9 @@ AWS_CRT_API void aws_crt_signing_config_aws_set_expiration_in_seconds(
 AWS_CRT_API void aws_crt_signing_config_aws_set_date(
     aws_crt_signing_config_aws *signing_config,
     uint64_t seconds_since_epoch);
+AWS_CRT_API void aws_crt_signing_config_aws_set_should_sign_header_fn(
+    aws_crt_signing_config_aws *signing_config,
+    aws_crt_should_sign_header_fn should_sign_header_fn);
 
 /* aws_signable */
 typedef struct aws_signable aws_crt_signable;

--- a/src/crt.h
+++ b/src/crt.h
@@ -7,6 +7,7 @@
 
 /* clang-format off */
 #include <aws/common/common.h> /* must be present so api.h knows about inttypes and allocators */
+#include <aws/common/byte_buf.h>
 #include "api.h"
 /* clang-format on */
 

--- a/src/signing.c
+++ b/src/signing.c
@@ -115,6 +115,12 @@ void aws_crt_signing_config_aws_set_date(aws_crt_signing_config_aws *signing_con
     aws_date_time_init_epoch_secs(&signing_config->config.date, (double)seconds_since_epoch);
 }
 
+void aws_crt_signing_config_aws_set_should_sign_header_fn(
+aws_crt_signing_config_aws *signing_config,
+    aws_crt_should_sign_header_fn should_sign_header_fn) {
+        signing_config->config.should_sign_header = should_sign_header_fn;
+}
+
 aws_crt_signable *aws_crt_signable_new_from_http_request(const aws_crt_http_message *request) {
     return aws_signable_new_http_request(aws_crt_default_allocator(), request->message);
 }


### PR DESCRIPTION
*Description of changes:*
Bindings to set the `should_sign_header_fn` on signing config exist and are required in the Ruby CRT bindings.  See:
* https://github.com/awslabs/aws-crt-ruby/blob/main/gems/aws-crt/native/src/signing_config.c#L27
* Used in our signing config: https://github.com/awslabs/aws-crt-ruby/blob/main/gems/aws-crt-auth/lib/aws-crt-auth/signing_config.rb#L72


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
