### PR TITLE
Remove debian-stretch CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
           - manylinux2014-x64
           - manylinux2014-x86
           - manylinux2014-aarch64
-          - debian-stretch-arm32v7
           - al2-x64
       fail-fast: false
     steps:


### PR DESCRIPTION
*Description of changes:*
- Remove Debian Stretch CI as Stretch is in archive state now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
